### PR TITLE
Allow executing the main of a module that only exists as FlatCurry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ export MINORVERSION=10
 # The revision version number:
 export REVISIONVERSION=0
 # The build version number (if >0, then it is a pre-release)
-export BUILDVERSION=2
+export BUILDVERSION=3
 # Complete version:
 export VERSION=$(MAJORVERSION).$(MINORVERSION).$(REVISIONVERSION)
 # The version date:

--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -1,7 +1,7 @@
 PAKCS: Release Notes
 ====================
 
-Release notes for PAKCS Version 3.10.0 (July 4, 2026)
+Release notes for PAKCS Version 3.10.0 (July 16, 2026)
 -----------------------------------------------------
 
 Changes to version 3.9.0:
@@ -25,6 +25,10 @@ Changes to version 3.9.0:
     FlatCurry expressions in a program with their corresponding types.
   * Add option `process-state` to provide a command to process a generated
     executable. This is used when invoking the docker image of PAKCS.
+  * Add command `:main` to execute the function `main` of the current module
+    (which must be of type `IO ()`).
+    This is useful to execute the main function of a module where the source
+    file does not exist, i.e., which is loaded from the FlatCurry file.
 
 
 Release notes for PAKCS Version 3.9.0 (October 29, 2025)

--- a/src/c2p.pl
+++ b/src/c2p.pl
@@ -572,6 +572,7 @@ writeAndParseExpression(MainExprDir,SplitFreeVars,Input,InitAcyType,
           ; showAcyQualType(InitAcyType,InitMainFuncType,Mods)),
         %write('MODULES: '), write(Mods), nl,
         getMainProgPath(MainProgName,MainPath),
+        write(getMainProgPath(MainProgName,MainPath)), nl,
 	appendAtoms([MainExprDir,'/PAKCS_Main_Exp'],MainExprMod),
 	appendAtoms([MainExprMod,'.curry'],MainExprModFile),
         addCurrentLetBindings(Input,LetInput),
@@ -663,16 +664,17 @@ getMainProgPath(CurrMod,MainPath) :-
 	    writeLnErr(LoadProg),
 	    writeErr('    main expression parsed w.r.t. source module: '),
 	    writeLnErr(CurrMod)).
-getMainProgPath(CurrMod,MainPath) :-
+getMainProgPath(CurrMod,_) :-
 	currentModuleFile(CurrMod,_),
 	( atom(CurrMod) -> CurrModAtom = CurrMod
 	; atom_codes(CurrModAtom,CurrMod) ),
-	findFlatProgFileInLoadPath(CurrModAtom,FlatProg), !,
-	atom_codes(FlatProg,FlatProgS),
-	appendAtoms([FlatProgS,'/..'],MainPath),
+	findFlatProgFileInLoadPath(CurrModAtom,_), !,
 	(verbosityQuiet -> true ;
-	    writeErr('*** Warning: module loaded from FlatCurry without source: '),
-	    writeLnErr(CurrMod)).
+	    writeErr('*** ERROR: cannot compile expression since module "'),
+	    writeErr(CurrMod),
+            writeLnErr('"'),
+            writeLnErr('           was loaded from FlatCurry without source file')),
+        !, fail.
 getMainProgPath(_,_) :-
 	lastload(MainProgS), atom_codes(MainProg,MainProgS),
 	writeErr('Source program for module "'), writeErr(MainProg),
@@ -852,7 +854,7 @@ processCommand("help",[]) :- !,
         write('let <p> = <expr>    - add let binding for main expression'), nl,
 	write(':load <prog>        - compile and load program "<prog>.curry" and all imports'),nl,
 	write(':reload             - recompile currently loaded modules'), nl,
-	write(':main               - execute the current module\'s main function'), nl,
+	write(':main               - execute function "main" (of type "IO ()")'), nl,
 	write(':add <m1> .. <mn>   - add modules <m1>,...,<mn> to currently loaded modules'),nl,
 	write(':eval <expr>        - evaluate expression <expr>'), nl,
 	write(':save               - save executable with main expression "main"'), nl,
@@ -952,7 +954,8 @@ processCommand("main",[]) :- !,
 	          ; true),
 	atom_codes(ProgA,Prog),
 	appendAtoms([ProgA,'.main'],MainExp),
-	call(evaluateMainExpression(MainExp, 'TCons'('Prelude.IO',[_]), [])).
+	call(evaluateMainExpression(MainExp,
+                        'TCons'('Prelude.IO',['TCons'('Prelude.()',[])]), [])).
 
 processCommand("eval",ExprInput) :- !,
 	processExpression(ExprInput,ExprGoal),

--- a/src/c2p.pl
+++ b/src/c2p.pl
@@ -356,7 +356,7 @@ prefixOf(Prefix,[_|FullS],Full) :- prefixOf(Prefix,FullS,Full).
 % all possible commands:
 allCommands(["add","browse","cd","compile","coosy",
              "edit","eval","fork","help", "info",
-	     "interface","load","modules","peval","programs","quit","reload",
+	     "interface","load","main","modules","peval","programs","quit","reload",
 	     "save","set","show","source","type","usedimports"]).
 
 % Expand an option that may be shortened to its full name:
@@ -413,7 +413,7 @@ process([58|Cs]) :- !, % 58=':'
 	(append(ShortCmd,[32|Rest],Cs) -> true ; ShortCmd=Cs, Rest=[]),
 	expandCommand(ShortCmd,Cmd),
 	removeBlanks(Rest,Params),
-	(member(Cmd,["load","reload","compile","quit","eval"])
+	(member(Cmd,["load","reload","compile","quit","eval","main"])
           -> true
            ; ioAdmissible),
 	processCommand(Cmd,Params),
@@ -663,6 +663,16 @@ getMainProgPath(CurrMod,MainPath) :-
 	    writeLnErr(LoadProg),
 	    writeErr('    main expression parsed w.r.t. source module: '),
 	    writeLnErr(CurrMod)).
+getMainProgPath(CurrMod,MainPath) :-
+	currentModuleFile(CurrMod,_),
+	( atom(CurrMod) -> CurrModAtom = CurrMod
+	; atom_codes(CurrModAtom,CurrMod) ),
+	findFlatProgFileInLoadPath(CurrModAtom,FlatProg), !,
+	atom_codes(FlatProg,FlatProgS),
+	appendAtoms([FlatProgS,'/..'],MainPath),
+	(verbosityQuiet -> true ;
+	    writeErr('*** Warning: module loaded from FlatCurry without source: '),
+	    writeLnErr(CurrMod)).
 getMainProgPath(_,_) :-
 	lastload(MainProgS), atom_codes(MainProg,MainProgS),
 	writeErr('Source program for module "'), writeErr(MainProg),
@@ -842,6 +852,7 @@ processCommand("help",[]) :- !,
         write('let <p> = <expr>    - add let binding for main expression'), nl,
 	write(':load <prog>        - compile and load program "<prog>.curry" and all imports'),nl,
 	write(':reload             - recompile currently loaded modules'), nl,
+	write(':main               - execute the current module\'s main function'), nl,
 	write(':add <m1> .. <mn>   - add modules <m1>,...,<mn> to currently loaded modules'),nl,
 	write(':eval <expr>        - evaluate expression <expr>'), nl,
 	write(':save               - save executable with main expression "main"'), nl,
@@ -934,6 +945,14 @@ processCommand("reload",[]) :- !,
 	                     asserta(spypoints([])),
 	                     singleOn, traceOn, spyOff
 	                   ; true).
+
+processCommand("main",[]) :- !,
+	currentprogram(Prog),
+	(Prog="" -> writeLnErr('ERROR: no program loaded'), !, fail
+	          ; true),
+	atom_codes(ProgA,Prog),
+	appendAtoms([ProgA,'.main'],MainExp),
+	call(evaluateMainExpression(MainExp, 'TCons'('Prelude.IO',[_]), [])).
 
 processCommand("eval",ExprInput) :- !,
 	processExpression(ExprInput,ExprGoal),
@@ -1269,7 +1288,7 @@ processCompile(ProgS,PrologFile) :-
 	verbosity(Verbosity),
 	parserWarnings(PWarnings),
         (Verbosity=0 -> Warnings=no ; Warnings=PWarnings),
-	parseProgram(ProgS,Verbosity,Warnings,'--flat'),
+	(findSourceProg(ProgS,_) -> parseProgram(ProgS,Verbosity,Warnings,'--flat') ; true),
 	prog2PrologFile(Prog,LocalPrologFile),
 	tryXml2Fcy(Prog),
 	(findFlatProgFileInLoadPath(Prog,PathProgName)
@@ -1692,7 +1711,8 @@ failprint(Exp,E,E) :-
 % Target: --flat or --acy
 
 parseProgram(ProgS,Verbosity,Warnings,Target) :-
-  	installDir(TCP),
+	findSourceProg(ProgS,_), !,
+   	installDir(TCP),
 	compilerMajorVersion(MajorVersion),
 	versionAtom(MajorVersion, MajorVersionAtom),
 	compilerMinorVersion(MinorVersion),


### PR DESCRIPTION
For Template-Haskell style metaprogramming, we need a way to execute "virtual" flat curry files for which no source module really exists. 